### PR TITLE
Changed coin name

### DIFF
--- a/src/curiumd-res.rc
+++ b/src/curiumd-res.rc
@@ -17,13 +17,13 @@ BEGIN
         BLOCK "040904E4" // U.S. English - multilingual (hex)
         BEGIN
             VALUE "CompanyName",        "Curium"
-            VALUE "FileDescription",    "Darkcoind (OSS daemon/client for Curium)"
+            VALUE "FileDescription",    "Curiumd (OSS daemon/client for Curium)"
             VALUE "FileVersion",        VER_FILEVERSION_STR
             VALUE "InternalName",       "curiumd"
             VALUE "LegalCopyright",     COPYRIGHT_STR
             VALUE "LegalTrademarks1",   "Distributed under the MIT/X11 software license, see the accompanying file COPYING or http://www.opensource.org/licenses/mit-license.php."
             VALUE "OriginalFilename",   "curiumd.exe"
-            VALUE "ProductName",        "Darkcoind"
+            VALUE "ProductName",        "Curiumd"
             VALUE "ProductVersion",     VER_PRODUCTVERSION_STR
         END
     END


### PR DESCRIPTION
There was still a reference with "Darkcoin" in there.